### PR TITLE
fix syntax  issue: remove useless 'the'

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -79,7 +79,7 @@
   </p>
   <p>
     While quantitative comparisons are useful, they only provide partial
-    insight into the how a recurrent unit memorizes. A model can, for example,
+    insight into how a recurrent unit memorizes. A model can, for example,
     achieve high accuracy and cross entropy loss by just providing highly accurate
     predictions in cases that only require short-term memorization, while
     being inaccurate at predictions that require long-term


### PR DESCRIPTION
Was reading and noticed a useless 'the' floating around, so removed it.

Great work!